### PR TITLE
Switch to disable evaluating classes in EL. FISH-899

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -39,6 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
+    Portions Copyright [2021] [Payara Foundation and/or its affiliates]
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -51,7 +51,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>javax.servlet.jsp</groupId>
     <artifactId>javax.servlet.jsp-api</artifactId>
-    <version>2.3.3</version>
+    <version>2.3.3.payara-p1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>JavaServer Pages(TM) API</name>
 
@@ -101,10 +101,10 @@
         </mailingList>
     </mailingLists>
     <scm>
-      <connection>scm:git:https://github.com/javaee/javaee-jsp-api.git</connection>
-      <developerConnection>scm:git:ssh://git@github.com/javaee/javaee-jsp-api.git</developerConnection>
-      <url>https://github.com/javaee/javaee-jsp-api</url>
-      <tag>2.3.3</tag>
+      <connection>scm:git:https://github.com/payara/patched-src-jsp-api</connection>
+      <developerConnection>scm:git:ssh://git@github.com/payara/patched-src-jsp-api.git</developerConnection>
+      <url>https://github.com/payara/patched-src-jsp-api</url>
+      <tag>2.3.3.payara-p1</tag>
     </scm>
 
     <build>

--- a/api/src/main/java/javax/servlet/jsp/el/ScopedAttributeELResolver.java
+++ b/api/src/main/java/javax/servlet/jsp/el/ScopedAttributeELResolver.java
@@ -54,6 +54,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Portions Copyright [2021] [Payara Foundation and/or its affiliates]
  */
 
 package javax.servlet.jsp.el;


### PR DESCRIPTION
Can be tagged with a release tag for version 2.3.3.payara-p1.

Adds a switch to disable evaluating classes in EL.
Also adds debug logging in case the expression cannot be evaluated.

Based on the 2.3.3 tag in the https://github.com/javaee/javaee-jsp-api repository. Or, more exactly, on the previous commit, because it seems that that commit should have been tagged instead.

Depends on https://github.com/payara/patched-src-uel-ri/pull/3.